### PR TITLE
int -> int64

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	// Get Followers
 	for cursor != 0 {
 		//dlion92 followers for now
-		io := &twitter.FollowerListParams{ScreenName: *nick, Cursor: int(cursor), Count: 200}
+		io := &twitter.FollowerListParams{ScreenName: *nick, Cursor: int64(cursor), Count: 200}
 		followers, resp, err := client.Followers.List(io)
 		if err != nil || resp.StatusCode != 200 {
 			color.Set(color.FgRed, color.BlinkSlow)


### PR DESCRIPTION
I opened #4 about this - I'm not sure if something changed in the twitter api or what, but I got

```
../../gocode/src/github.com/dlion/go-odbye/main.go:110: cannot use int(cursor) (type int) as type int64 in field value
```

when I ran `go get -u -v github.com/dlion/go-odbye`

It was an easy enough fix though, just change int to int64