### PR TITLE
Adds Nick as optional config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ To use this tool you need to add your consumer and token key/secret in a json co
 }
 ```
 
+You can also optionally set your default nick in the config file
+```js
+{
+  "nick": "<yournick>",
+  // …
+}
+```
+
 ## Consumer/Token
 You can obtain your consumer/token creating a new twitter application, see https://apps.twitter.com/ to more info.
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type fUser struct {
 }
 
 type Conf struct {
+	Nick           string `json:"nick,omitempty"`
 	ConsumerKey    string `json:"consumerKey"`
 	ConsumerSecret string `json:"consumerSecret"`
 	AccessToken    string `json:"accessToken"`
@@ -55,7 +56,12 @@ func main() {
 	//Cursor
 	cursor := int64(-1)
 
-	nick := flag.String("nick", "dlion92", "your nickname on twitter")
+	defaultNick := "dlion92"
+	if configuration.Nick != "" {
+		defaultNick = configuration.Nick
+	}
+
+	nick := flag.String("nick", defaultNick, "your nickname on twitter")
 	url := flag.Bool("url", false, "true if you want to see the url in output")
 
 	flag.Parse()


### PR DESCRIPTION
I often forget the `-nick` param ending up in my history being trampled by yours. This adds the option to set the default nick in the config file.