### PR TITLE
Fix INSERT OR IGNORE query

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	_, err = tx.Exec("INSERT OR IGNORE INTO users SELECT * FROM usersTmp")
+	_, err = tx.Exec("INSERT OR IGNORE INTO users (idUser, username, firstSeen) SELECT idUser, username, firstSeen FROM usersTmp")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Thank you for accepting #10! Sadly I introduced a bug I didn't see until I got some churn in my subscribers.

When the auto increment `id` of users in `usersTmp` don't line up with the ids in `users`, you end up with `OR IGNORE`'d inserts that shouldn't have been skipped.

Simple solution is just to remove `id` from the `INSERT OR IGNORE`